### PR TITLE
Fix version branch name

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,3 +1,3 @@
 [
-    {"required_api_version": "^2.0.0", "commit" : "master"}
+    {"required_api_version": "^2.0.0", "commit" : "main"}
 ]


### PR DESCRIPTION
The installation of the extension was broken due to the `versions.json` referencing the old branch name `master` instead of the correct `main`.